### PR TITLE
profile page 404 error

### DIFF
--- a/pro-alx-UI/src/components/details/View.jsx
+++ b/pro-alx-UI/src/components/details/View.jsx
@@ -108,7 +108,7 @@ export const Details = ({ user }) => {
 					user?.most_active_time ? user?.most_active_time : 'not available'
 				}`}
       </span>
-      {user?.requested_partners && (
+      {user?.requested_project && (
         <p className='py-4 border-y my-3 dark:border-gray-700  border-gray-500 text-blue-950 dark:text-blue-100 '>
           <span>
             {`${user?.name} currently needs ${user?.requested_partners} Partner(s) for the ${user?.requested_project} team project`}

--- a/pro-alx-UI/src/hooks/useCustomQuery.js
+++ b/pro-alx-UI/src/hooks/useCustomQuery.js
@@ -43,9 +43,7 @@ export const useCustomQuery = ({ queryKey, endpoint, ...others }) => {
       toast.error('An error occurred');
       return err;
     },
-    onSettled: () => {
-
-    }
+    onSettled: () => {}
   });
   return {
     ...results,
@@ -116,11 +114,21 @@ export const useCustomMutation = ({
 
         // if another state needs to be updated as well, the query key is passed as secondKey(user profile)
         if (secondKey.length > 0) {
+          // check if the payload returned is an empty object
+          const isDataEmpty = Object.keys(data.data).length === 0;
+
           queryClient.setQueryData(secondKey, prev => {
             if (prev) {
+              const updatedUserData = isDataEmpty
+                ? {
+                    ...prev.data.user,
+                    requested_project: '',
+                    requested_partners: 0
+								  }
+                : { ...data.data };
               return {
                 ...prev,
-                data: { ...prev?.data, user: { ...data.data } }
+                data: { ...prev?.data, user: updatedUserData }
               };
             }
           });
@@ -128,9 +136,7 @@ export const useCustomMutation = ({
         return data;
       }
     },
-    onSettled: () => {
-
-    }
+    onSettled: () => {}
   });
   return {
     ...results,


### PR DESCRIPTION
## Bug fixed
Issue: After a user cancels their partner request, navigating to their profile page redirects to 404 page

Bug: payload returned after removal from partner list is an empty object. So previously the user profile was updated to an empty object after cancelling partner request.

Fix: check if payload returned is empty before updating the cache memory after a successful mutation.